### PR TITLE
fix: replication audit now covers all local chunks, not just uploaded…

### DIFF
--- a/internal/server/chunked_ops.go
+++ b/internal/server/chunked_ops.go
@@ -90,6 +90,7 @@ func (s *FileServer) handleRelayStream(from string, rpc p2p.RPC) error {
 			return fmt.Errorf("failed to store relay stream data for %s: %w", meta.Key, err)
 		}
 		fmt.Printf("[%s] Stored relay stream chunk %s: %d bytes (verified)\n", s.Transport.Addr(), meta.Key, n)
+		s.ChunkLedger.Add(meta.Key)
 		s.notifyChunkArrived(meta.Key)
 		return nil
 	}
@@ -217,6 +218,7 @@ func (s *FileServer) handleStoreManifest(from string, msg MessageStoreManifest) 
 		return fmt.Errorf("failed to store manifest: %w", err)
 	}
 	fmt.Printf("[%s] Manifest %s stored: %d bytes\n", s.Transport.Addr(), msg.Key, n)
+	s.ChunkLedger.Add(msg.Key)
 	return nil
 }
 
@@ -396,6 +398,7 @@ func (s *FileServer) handleChunkData(from string, msg MessageChunkData) error {
 	}
 	fmt.Printf("[%s] Stored chunk %s (%d bytes, verified) from %s\n",
 		s.Transport.Addr(), msg.ChunkKey[:16], n, from)
+	s.ChunkLedger.Add(msg.ChunkKey)
 	s.notifyChunkArrived(msg.ChunkKey)
 	return nil
 }
@@ -653,6 +656,13 @@ func (s *FileServer) StoreDataChunked(originalName string, userEncryptionKey []b
 		Size:         totalSize,
 		ChunkCount:   len(chunks),
 	})
+
+	// track every chunk + manifest in the ledger so this node
+	// can audit them even if we're not the original uploader
+	for _, ck := range chunkKeys {
+		s.ChunkLedger.Add(ck)
+	}
+	s.ChunkLedger.Add(manifestKey)
 
 	return cid, nil
 }

--- a/internal/server/chunked_ops.go
+++ b/internal/server/chunked_ops.go
@@ -90,7 +90,9 @@ func (s *FileServer) handleRelayStream(from string, rpc p2p.RPC) error {
 			return fmt.Errorf("failed to store relay stream data for %s: %w", meta.Key, err)
 		}
 		fmt.Printf("[%s] Stored relay stream chunk %s: %d bytes (verified)\n", s.Transport.Addr(), meta.Key, n)
-		s.ChunkLedger.Add(meta.Key)
+		if err := s.ChunkLedger.Add(meta.Key); err != nil {
+			fmt.Printf("[%s] Warning: failed to add relay chunk to ledger: %v\n", s.Transport.Addr(), err)
+		}
 		s.notifyChunkArrived(meta.Key)
 		return nil
 	}
@@ -218,7 +220,9 @@ func (s *FileServer) handleStoreManifest(from string, msg MessageStoreManifest) 
 		return fmt.Errorf("failed to store manifest: %w", err)
 	}
 	fmt.Printf("[%s] Manifest %s stored: %d bytes\n", s.Transport.Addr(), msg.Key, n)
-	s.ChunkLedger.Add(msg.Key)
+	if err := s.ChunkLedger.Add(msg.Key); err != nil {
+		fmt.Printf("[%s] Warning: failed to add manifest to ledger: %v\n", s.Transport.Addr(), err)
+	}
 	return nil
 }
 
@@ -398,7 +402,9 @@ func (s *FileServer) handleChunkData(from string, msg MessageChunkData) error {
 	}
 	fmt.Printf("[%s] Stored chunk %s (%d bytes, verified) from %s\n",
 		s.Transport.Addr(), msg.ChunkKey[:16], n, from)
-	s.ChunkLedger.Add(msg.ChunkKey)
+	if err := s.ChunkLedger.Add(msg.ChunkKey); err != nil {
+		fmt.Printf("[%s] Warning: failed to add chunk to ledger: %v\n", s.Transport.Addr(), err)
+	}
 	s.notifyChunkArrived(msg.ChunkKey)
 	return nil
 }
@@ -521,6 +527,11 @@ func (s *FileServer) StoreDataChunked(originalName string, userEncryptionKey []b
 		totalSize += c.Size
 	}
 
+	// register chunks in the ledger immediately since they are now on disk
+	if err := s.ChunkLedger.AddBatch(chunkKeys); err != nil {
+		fmt.Printf("[%s] Warning: failed to batch add chunks to ledger: %v\n", s.Transport.Addr(), err)
+	}
+
 	manifest := FileManifest{
 		OriginalKey: originalName, // human-readable name, not the network key
 		TotalSize:   totalSize,
@@ -536,6 +547,10 @@ func (s *FileServer) StoreDataChunked(originalName string, userEncryptionKey []b
 	}
 	if _, err := s.Store.WriteStream(manifestKey, &manifestBuf); err != nil {
 		return "", fmt.Errorf("failed to store manifest: %w", err)
+	}
+	
+	if err := s.ChunkLedger.Add(manifestKey); err != nil {
+		fmt.Printf("[%s] Warning: failed to add manifest to ledger: %v\n", s.Transport.Addr(), err)
 	}
 
 	fmt.Printf("[%s] File stored: CID=%s, name=%s, %d chunks, %d bytes\n",
@@ -656,13 +671,6 @@ func (s *FileServer) StoreDataChunked(originalName string, userEncryptionKey []b
 		Size:         totalSize,
 		ChunkCount:   len(chunks),
 	})
-
-	// track every chunk + manifest in the ledger so this node
-	// can audit them even if we're not the original uploader
-	for _, ck := range chunkKeys {
-		s.ChunkLedger.Add(ck)
-	}
-	s.ChunkLedger.Add(manifestKey)
 
 	return cid, nil
 }

--- a/internal/server/delete_ops.go
+++ b/internal/server/delete_ops.go
@@ -55,6 +55,8 @@ func (s *FileServer) DeleteFile(cid string) error {
 		if s.Store.Has(key) {
 			if err := s.Store.DeleteStream(key); err != nil {
 				fmt.Printf("[%s] Warning: failed to delete local bytes for %s: %v\n", s.Transport.Addr(), truncateKey(key, 16), err)
+			} else {
+				s.ChunkLedger.Remove(key)
 			}
 		}
 	}
@@ -144,6 +146,7 @@ func (s *FileServer) handleDeleteFile(_ string, msg MessageDeleteFile) error {
 			if err := s.Store.DeleteStream(t.ChunkKey); err != nil {
 				fmt.Printf("[%s] Warning: failed to delete bytes for %s: %v\n", s.Transport.Addr(), truncateKey(t.ChunkKey, 16), err)
 			} else {
+				s.ChunkLedger.Remove(t.ChunkKey)
 				fmt.Printf("[%s] Deleted chunk %s (tombstoned by peer)\n", s.Transport.Addr(), truncateKey(t.ChunkKey, 16))
 			}
 		}
@@ -191,6 +194,8 @@ func (s *FileServer) handleTombstoneSync(_ string, msg MessageTombstoneSync) err
 		if err := s.Store.DeleteStream(t.ChunkKey); err != nil {
 			fmt.Printf("[%s] Warning: failed to delete bytes for synced tombstone %s: %v\n",
 				s.Transport.Addr(), truncateKey(t.ChunkKey, 16), err)
+		} else {
+			s.ChunkLedger.Remove(t.ChunkKey)
 		}
 	}
 
@@ -235,6 +240,7 @@ func (s *FileServer) runGC() {
 				fmt.Printf("[%s] GC: failed to delete %s: %v\n", s.Transport.Addr(), truncateKey(t.ChunkKey, 16), err)
 				continue
 			}
+			s.ChunkLedger.Remove(t.ChunkKey)
 			cleaned++
 		}
 	}

--- a/internal/server/delete_ops.go
+++ b/internal/server/delete_ops.go
@@ -52,11 +52,19 @@ func (s *FileServer) DeleteFile(cid string) error {
 		})
 		// delete the bytes immediately from local CAS
 		// if this fails, the GC loop will clean them up later — tombstone is already set
-		if s.Store.Has(key) {
+		// if the bytes are already absent, or we delete them successfully,
+		// we MUST remove the key from the ledger so it doesn't stay around forever.
+		if !s.Store.Has(key) {
+			if err := s.ChunkLedger.Remove(key); err != nil {
+				fmt.Printf("[%s] Warning: failed to remove missing chunk %s from ledger: %v\n", s.Transport.Addr(), truncateKey(key, 16), err)
+			}
+		} else {
 			if err := s.Store.DeleteStream(key); err != nil {
 				fmt.Printf("[%s] Warning: failed to delete local bytes for %s: %v\n", s.Transport.Addr(), truncateKey(key, 16), err)
 			} else {
-				s.ChunkLedger.Remove(key)
+				if err := s.ChunkLedger.Remove(key); err != nil {
+					fmt.Printf("[%s] Warning: failed to remove deleted chunk %s from ledger: %v\n", s.Transport.Addr(), truncateKey(key, 16), err)
+				}
 			}
 		}
 	}
@@ -142,11 +150,17 @@ func (s *FileServer) handleDeleteFile(_ string, msg MessageDeleteFile) error {
 			continue // don't delete bytes without a persisted tombstone
 		}
 		// delete local bytes
-		if s.Store.Has(t.ChunkKey) {
+		if !s.Store.Has(t.ChunkKey) {
+			if err := s.ChunkLedger.Remove(t.ChunkKey); err != nil {
+				fmt.Printf("[%s] Warning: failed to remove missing chunk %s from ledger: %v\n", s.Transport.Addr(), truncateKey(t.ChunkKey, 16), err)
+			}
+		} else {
 			if err := s.Store.DeleteStream(t.ChunkKey); err != nil {
 				fmt.Printf("[%s] Warning: failed to delete bytes for %s: %v\n", s.Transport.Addr(), truncateKey(t.ChunkKey, 16), err)
 			} else {
-				s.ChunkLedger.Remove(t.ChunkKey)
+				if err := s.ChunkLedger.Remove(t.ChunkKey); err != nil {
+					fmt.Printf("[%s] Warning: failed to remove deleted chunk %s from ledger: %v\n", s.Transport.Addr(), truncateKey(t.ChunkKey, 16), err)
+				}
 				fmt.Printf("[%s] Deleted chunk %s (tombstoned by peer)\n", s.Transport.Addr(), truncateKey(t.ChunkKey, 16))
 			}
 		}
@@ -189,13 +203,18 @@ func (s *FileServer) handleTombstoneSync(_ string, msg MessageTombstoneSync) err
 		}
 
 		if !s.Store.Has(t.ChunkKey) {
+			if err := s.ChunkLedger.Remove(t.ChunkKey); err != nil {
+				fmt.Printf("[%s] Warning: failed to remove missing synced chunk %s from ledger: %v\n", s.Transport.Addr(), truncateKey(t.ChunkKey, 16), err)
+			}
 			continue
 		}
 		if err := s.Store.DeleteStream(t.ChunkKey); err != nil {
 			fmt.Printf("[%s] Warning: failed to delete bytes for synced tombstone %s: %v\n",
 				s.Transport.Addr(), truncateKey(t.ChunkKey, 16), err)
 		} else {
-			s.ChunkLedger.Remove(t.ChunkKey)
+			if err := s.ChunkLedger.Remove(t.ChunkKey); err != nil {
+				fmt.Printf("[%s] Warning: failed to remove deleted synced chunk %s from ledger: %v\n", s.Transport.Addr(), truncateKey(t.ChunkKey, 16), err)
+			}
 		}
 	}
 
@@ -235,12 +254,18 @@ func (s *FileServer) runGC() {
 
 	for _, t := range tombstones {
 		// make sure bytes are gone
-		if s.Store.Has(t.ChunkKey) {
+		if !s.Store.Has(t.ChunkKey) {
+			if err := s.ChunkLedger.Remove(t.ChunkKey); err != nil {
+				fmt.Printf("[%s] GC: failed to remove missing chunk %s from ledger: %v\n", s.Transport.Addr(), truncateKey(t.ChunkKey, 16), err)
+			}
+		} else {
 			if err := s.Store.DeleteStream(t.ChunkKey); err != nil {
 				fmt.Printf("[%s] GC: failed to delete %s: %v\n", s.Transport.Addr(), truncateKey(t.ChunkKey, 16), err)
 				continue
 			}
-			s.ChunkLedger.Remove(t.ChunkKey)
+			if err := s.ChunkLedger.Remove(t.ChunkKey); err != nil {
+				fmt.Printf("[%s] GC: failed to remove deleted chunk %s from ledger: %v\n", s.Transport.Addr(), truncateKey(t.ChunkKey, 16), err)
+			}
 			cleaned++
 		}
 	}

--- a/internal/server/replication.go
+++ b/internal/server/replication.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -334,42 +335,37 @@ func (s *FileServer) runReplicationAudit() {
 	}
 	defer s.auditLock.Unlock()
 
-	entries := s.CIDIndex.List()
-	if len(entries) == 0 {
+	// ---- THE FIX: iterate the chunk ledger instead of CIDIndex ----
+	// CIDIndex only has files WE uploaded. the ledger has EVERY chunk
+	// on our disk — including replicas from other nodes. this means
+	// if the original uploader dies, WE can still detect and fix
+	// under-replication for those chunks.
+	allChunks := s.ChunkLedger.All()
+	if len(allChunks) == 0 {
 		return
 	}
 
-	// ---- Phase 1: collect all chunk keys from our manifests ----
-	// also build an ownership set so we don't have to re-read manifests
-	// later in handleOverReplication / handleDropChunk for each chunk.
-	var allChunks []string
-	ownedChunks := make(map[string]bool)
-	for _, entry := range entries {
-		manifestKey := entry.CID + ".manifest"
-		manifest, err := s.loadManifest(manifestKey)
-		if err != nil {
+	// filter out tombstoned chunks and manifests — manifests aren't
+	// independently replicated, they ride along with the file's chunks
+	filtered := make([]string, 0, len(allChunks))
+	for _, ck := range allChunks {
+		if s.Tombstones.IsDead(ck) || strings.HasSuffix(ck, ".manifest") {
 			continue
 		}
-		for _, chunkKey := range manifest.ChunkKeys {
-			if s.Tombstones.IsDead(chunkKey) {
-				continue
-			}
-			// dedup — CAS means multiple files can reference the same chunk.
-			// without this check the same chunk gets audited/pushed/dropped twice.
-			if ownedChunks[chunkKey] {
-				continue
-			}
-			allChunks = append(allChunks, chunkKey)
-			ownedChunks[chunkKey] = true
-		}
+		filtered = append(filtered, ck)
 	}
+	allChunks = filtered
 
 	if len(allChunks) == 0 {
 		return
 	}
 
-	fmt.Printf("[%s] Replication audit: checking %d chunks across %d files\n",
-		s.Transport.Addr(), len(allChunks), len(entries))
+	// pre-compute which chunks belong to files we uploaded.
+	// handleOverReplication uses this to avoid dropping our own files' chunks.
+	ownedChunks := s.buildOwnedChunkSet()
+
+	fmt.Printf("[%s] Replication audit: checking %d chunks (%d owned by us)\n",
+		s.Transport.Addr(), len(allChunks), len(ownedChunks))
 
 	// ---- Phase 1b: send ONE batch query per peer, collect ALL responses ----
 	// now returns a map of chunkKey -> set of holder addresses, not just counts.
@@ -422,6 +418,24 @@ func (s *FileServer) runReplicationAudit() {
 	for _, a := range overActions {
 		s.handleOverReplication(a.key, a.holders, ownedChunks)
 	}
+}
+
+// buildOwnedChunkSet returns a set of chunk keys that belong to files
+// this node uploaded. used during over-replication to make sure we
+// never drop chunks from our own files — only excess replicas we're
+// holding for someone else.
+func (s *FileServer) buildOwnedChunkSet() map[string]bool {
+	owned := make(map[string]bool)
+	for _, entry := range s.CIDIndex.List() {
+		manifest, err := s.loadManifest(entry.CID + ".manifest")
+		if err != nil {
+			continue
+		}
+		for _, ck := range manifest.ChunkKeys {
+			owned[ck] = true
+		}
+	}
+	return owned
 }
 
 // batchAuditChunks sends ONE query per peer with ALL chunk keys,
@@ -755,6 +769,7 @@ func (s *FileServer) handleDropChunk(_ string, msg MessageDropChunk) error {
 	if err := s.Store.DeleteStream(msg.ChunkKey); err != nil {
 		return fmt.Errorf("failed to drop chunk %s: %w", truncateKey(msg.ChunkKey, 16), err)
 	}
+	s.ChunkLedger.Remove(msg.ChunkKey)
 
 	fmt.Printf("[%s] Dropped chunk %s (over-replicated, freed up space)\n",
 		s.Transport.Addr(), truncateKey(msg.ChunkKey, 16))

--- a/internal/server/replication.go
+++ b/internal/server/replication.go
@@ -634,6 +634,9 @@ func (s *FileServer) handleOverReplication(chunkKey string, holders holderSet, o
 				fmt.Printf("[%s] Failed to drop our chunk %s: %v\n",
 					s.Transport.Addr(), truncateKey(chunkKey, 16), err)
 			} else {
+				if err := s.ChunkLedger.Remove(chunkKey); err != nil {
+					fmt.Printf("[%s] Warning: failed to remove dropped chunk %s from ledger: %v\n", s.Transport.Addr(), truncateKey(chunkKey, 16), err)
+				}
 				dropped++
 			}
 		} else {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -81,6 +81,9 @@ func NewFileServer(options FileServerOptions) *FileServer {
 	store := storage.NewStore(options.RootDir)
 	id := dht.NewID(options.ID)
 
+	chunkLedger, needsRebuild := storage.NewChunkLedger(options.RootDir)
+	cidIndex := storage.NewCIDIndex(options.RootDir)
+
 	s := &FileServer{
 		FileServerOptions: options,
 		ID:                id,
@@ -92,8 +95,8 @@ func NewFileServer(options FileServerOptions) *FileServer {
 		verifiedAddrs:     make(map[string]bool),
 		addrMap:           make(map[string]string),
 		relayPeers:        make(map[string]bool),
-		CIDIndex:          storage.NewCIDIndex(options.RootDir),
-		ChunkLedger:       storage.NewChunkLedger(options.RootDir),
+		CIDIndex:          cidIndex,
+		ChunkLedger:       chunkLedger,
 		peerProfiles:      make(map[string]StorageProfile),
 		peerHealth:        make(map[string]*PeerHealth),
 		HeartbeatInterval: DefaultHeartbeatInterval,
@@ -105,6 +108,32 @@ func NewFileServer(options FileServerOptions) *FileServer {
 	// wire up the RL placement optimizer if a sidecar URL was provided
 	s.Optimizer = NewPlacementOptimizer(options.RLSidecarURL)
 	s.Metrics = NewPlacementMetrics()
+
+	// Rebuild chunk ledger if it was missing or corrupted
+	if needsRebuild {
+		fmt.Printf("[Server %s] ChunkLedger missing or corrupt, rebuilding from CIDIndex...\n", s.AdvertiseAddr)
+		var keysToRecover []string
+		for _, entry := range cidIndex.List() {
+			manifestKey := entry.CID + ".manifest"
+			keysToRecover = append(keysToRecover, manifestKey)
+
+			if size, r, err := store.ReadStream(manifestKey); err == nil {
+				var manifest FileManifest
+				if err := gob.NewDecoder(r).Decode(&manifest); err == nil {
+					keysToRecover = append(keysToRecover, manifest.ChunkKeys...)
+				}
+				r.Close()
+				_ = size // ignore size
+			}
+		}
+		if len(keysToRecover) > 0 {
+			if err := chunkLedger.AddBatch(keysToRecover); err != nil {
+				fmt.Printf("[Server %s] Warning: failed to rebuild ChunkLedger: %v\n", s.AdvertiseAddr, err)
+			} else {
+				fmt.Printf("[Server %s] Rebuilt ChunkLedger with %d keys from CIDIndex\n", s.AdvertiseAddr, len(keysToRecover))
+			}
+		}
+	}
 
 	return s
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -44,7 +44,8 @@ type FileServer struct {
 	addrMap       map[string]string // raw TCP remote addr --> advertised listen addr
 	relayPeers    map[string]bool   // map of advertised addrs that are RelayOnly=true
 	pendingChunks sync.Map          // chunkKey --> chan struct{}, signals when a requested chunk arrives
-	CIDIndex      *storage.CIDIndex // local index mapping CID --> original filename
+	CIDIndex      *storage.CIDIndex    // local index mapping CID --> original filename
+	ChunkLedger   *storage.ChunkLedger // tracks ALL chunk keys on disk (uploaded + replicas)
 
 	// peer storage profiles for RL placement decisions.
 	// populated during PeerExchange -- maps advertise addr to hardware fingerprint.
@@ -92,6 +93,7 @@ func NewFileServer(options FileServerOptions) *FileServer {
 		addrMap:           make(map[string]string),
 		relayPeers:        make(map[string]bool),
 		CIDIndex:          storage.NewCIDIndex(options.RootDir),
+		ChunkLedger:       storage.NewChunkLedger(options.RootDir),
 		peerProfiles:      make(map[string]StorageProfile),
 		peerHealth:        make(map[string]*PeerHealth),
 		HeartbeatInterval: DefaultHeartbeatInterval,

--- a/internal/storage/chunk_ledger.go
+++ b/internal/storage/chunk_ledger.go
@@ -1,0 +1,127 @@
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// ChunkLedger tracks every chunk key stored on this node's disk.
+// unlike CIDIndex (which only knows about files WE uploaded),
+// this tracks ALL chunks — including replicas received from other nodes.
+// this is what the replication audit iterates so that EVERY node
+// can detect under-replication and re-replicate, not just the uploader.
+type ChunkLedger struct {
+	path string
+	mu   sync.RWMutex
+	keys map[string]struct{}
+}
+
+// NewChunkLedger loads (or creates) the ledger at <rootDir>/chunk_ledger.json.
+func NewChunkLedger(rootDir string) *ChunkLedger {
+	cl := &ChunkLedger{
+		path: filepath.Join(rootDir, "chunk_ledger.json"),
+		keys: make(map[string]struct{}),
+	}
+	cl.load()
+	return cl
+}
+
+// Add registers a chunk key in the ledger. idempotent — adding a key
+// that already exists is a no-op (but still persists, just in case
+// a previous save was interrupted).
+func (cl *ChunkLedger) Add(key string) {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+
+	cl.keys[key] = struct{}{}
+	if err := cl.save(); err != nil {
+		fmt.Printf("[ChunkLedger] warning: failed to persist after Add(%s): %v\n", key[:min(16, len(key))], err)
+	}
+}
+
+// Remove deletes a chunk key from the ledger. no-op if the key isn't tracked.
+func (cl *ChunkLedger) Remove(key string) {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+
+	if _, exists := cl.keys[key]; !exists {
+		return
+	}
+	delete(cl.keys, key)
+	if err := cl.save(); err != nil {
+		fmt.Printf("[ChunkLedger] warning: failed to persist after Remove(%s): %v\n", key[:min(16, len(key))], err)
+	}
+}
+
+// Has checks if a chunk key is tracked in the ledger.
+func (cl *ChunkLedger) Has(key string) bool {
+	cl.mu.RLock()
+	defer cl.mu.RUnlock()
+	_, exists := cl.keys[key]
+	return exists
+}
+
+// All returns a snapshot of every chunk key in the ledger.
+func (cl *ChunkLedger) All() []string {
+	cl.mu.RLock()
+	defer cl.mu.RUnlock()
+
+	result := make([]string, 0, len(cl.keys))
+	for k := range cl.keys {
+		result = append(result, k)
+	}
+	return result
+}
+
+// Count returns how many chunk keys are tracked.
+func (cl *ChunkLedger) Count() int {
+	cl.mu.RLock()
+	defer cl.mu.RUnlock()
+	return len(cl.keys)
+}
+
+// load reads the ledger from disk. if the file doesn't exist, we start empty.
+// if it's corrupted, we log a warning and start empty — the ledger will
+// get repopulated as chunks arrive or are audited by the network.
+func (cl *ChunkLedger) load() {
+	data, err := os.ReadFile(cl.path)
+	if err != nil {
+		return // file doesn't exist yet, start fresh
+	}
+
+	var keys []string
+	if err := json.Unmarshal(data, &keys); err != nil {
+		// unlike CIDIndex which silently starts empty on corruption,
+		// at least yell about it so someone notices
+		fmt.Printf("[ChunkLedger] WARNING: %s is corrupted, starting empty: %v\n", cl.path, err)
+		return
+	}
+	for _, k := range keys {
+		cl.keys[k] = struct{}{}
+	}
+}
+
+// save writes the ledger to disk atomically: write to .tmp, then rename.
+// this prevents the corruption-on-crash bug that cid_index.json has,
+// where a partial write leaves a broken file that gets silently wiped on reboot.
+func (cl *ChunkLedger) save() error {
+	keys := make([]string, 0, len(cl.keys))
+	for k := range cl.keys {
+		keys = append(keys, k)
+	}
+
+	data, err := json.Marshal(keys)
+	if err != nil {
+		return err
+	}
+
+	// write to a temp file first, then atomic rename
+	tmpPath := cl.path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, cl.path)
+}

--- a/internal/storage/chunk_ledger.go
+++ b/internal/storage/chunk_ledger.go
@@ -20,40 +20,79 @@ type ChunkLedger struct {
 }
 
 // NewChunkLedger loads (or creates) the ledger at <rootDir>/chunk_ledger.json.
-func NewChunkLedger(rootDir string) *ChunkLedger {
+// It returns the ledger and a boolean indicating if it was missing or corrupted (needs rebuild).
+func NewChunkLedger(rootDir string) (*ChunkLedger, bool) {
 	cl := &ChunkLedger{
 		path: filepath.Join(rootDir, "chunk_ledger.json"),
 		keys: make(map[string]struct{}),
 	}
-	cl.load()
-	return cl
+	needsRebuild := cl.load()
+	return cl, needsRebuild
 }
 
 // Add registers a chunk key in the ledger. idempotent — adding a key
-// that already exists is a no-op (but still persists, just in case
-// a previous save was interrupted).
-func (cl *ChunkLedger) Add(key string) {
+// that already exists is a no-op. Returns an error if persistence fails,
+// rolling back the in-memory state so it doesn't get out of sync with disk.
+func (cl *ChunkLedger) Add(key string) error {
 	cl.mu.Lock()
 	defer cl.mu.Unlock()
 
+	if _, exists := cl.keys[key]; exists {
+		return nil
+	}
+
 	cl.keys[key] = struct{}{}
 	if err := cl.save(); err != nil {
-		fmt.Printf("[ChunkLedger] warning: failed to persist after Add(%s): %v\n", key[:min(16, len(key))], err)
+		delete(cl.keys, key) // rollback
+		return fmt.Errorf("failed to persist ledger after Add: %w", err)
 	}
+	return nil
+}
+
+// AddBatch adds multiple chunk keys under a single lock and single disk write.
+// Ideal for file uploads with many chunks.
+func (cl *ChunkLedger) AddBatch(keys []string) error {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+
+	added := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if _, exists := cl.keys[k]; !exists {
+			cl.keys[k] = struct{}{}
+			added = append(added, k)
+		}
+	}
+
+	if len(added) == 0 {
+		return nil
+	}
+
+	if err := cl.save(); err != nil {
+		// rollback
+		for _, k := range added {
+			delete(cl.keys, k)
+		}
+		return fmt.Errorf("failed to persist ledger after AddBatch: %w", err)
+	}
+	return nil
 }
 
 // Remove deletes a chunk key from the ledger. no-op if the key isn't tracked.
-func (cl *ChunkLedger) Remove(key string) {
+// Rolls back if persistence fails.
+func (cl *ChunkLedger) Remove(key string) error {
 	cl.mu.Lock()
 	defer cl.mu.Unlock()
 
 	if _, exists := cl.keys[key]; !exists {
-		return
+		return nil
 	}
+	
 	delete(cl.keys, key)
 	if err := cl.save(); err != nil {
-		fmt.Printf("[ChunkLedger] warning: failed to persist after Remove(%s): %v\n", key[:min(16, len(key))], err)
+		cl.keys[key] = struct{}{} // rollback
+		return fmt.Errorf("failed to persist ledger after Remove: %w", err)
 	}
+	return nil
 }
 
 // Has checks if a chunk key is tracked in the ledger.
@@ -83,25 +122,27 @@ func (cl *ChunkLedger) Count() int {
 	return len(cl.keys)
 }
 
-// load reads the ledger from disk. if the file doesn't exist, we start empty.
-// if it's corrupted, we log a warning and start empty — the ledger will
-// get repopulated as chunks arrive or are audited by the network.
-func (cl *ChunkLedger) load() {
+// load reads the ledger from disk.
+// Returns true if the file was missing or corrupted (so caller knows to rebuild it).
+func (cl *ChunkLedger) load() bool {
 	data, err := os.ReadFile(cl.path)
 	if err != nil {
-		return // file doesn't exist yet, start fresh
+		if os.IsNotExist(err) {
+			return true // missing, needs rebuild for existing nodes
+		}
+		fmt.Printf("[ChunkLedger] WARNING: failed to read %s: %v\n", cl.path, err)
+		return true // treat error as needing rebuild
 	}
 
 	var keys []string
 	if err := json.Unmarshal(data, &keys); err != nil {
-		// unlike CIDIndex which silently starts empty on corruption,
-		// at least yell about it so someone notices
-		fmt.Printf("[ChunkLedger] WARNING: %s is corrupted, starting empty: %v\n", cl.path, err)
-		return
+		fmt.Printf("[ChunkLedger] WARNING: %s is corrupted, needs rebuild: %v\n", cl.path, err)
+		return true
 	}
 	for _, k := range keys {
 		cl.keys[k] = struct{}{}
 	}
+	return false
 }
 
 // save writes the ledger to disk atomically: write to .tmp, then rename.


### PR DESCRIPTION
 Added ChunkLedger , a local index of ALL chunk keys stored on this node's disk (both uploaded and received as replicas). The replication audit iterates the ledger instead of CIDIndex.

<img width="523" height="465" alt="image" src="https://github.com/user-attachments/assets/aa1357f0-beb4-4917-b070-b49c84e46092" />

NOTE : CIDIndex is NOT being removed. It still serves its purpose for ls, delete, and isOwnedChunk() (preventing over-replication from dropping chunks you uploaded). The ledger is a separate, broader index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent tracking of chunks stored on each server.
  * Improved replication audits to include locally stored replicas.
  * Added safeguards to exclude deleted or tombstoned content from replication ownership checks.
  * Added automatic recovery when chunk tracking data is missing or corrupted.

* **Bug Fixes**
  * Chunk records are now removed from tracking after successful deletion or cleanup.
  * Tracking remains accurate when chunks, manifests, and locally created files are stored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->